### PR TITLE
Use base64 -d on all Linux platforms and --decode on others

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -11,12 +11,25 @@ function tobool() {
   fi
 }
 
-_temp_dir=$(echo "$1" | base64 -d); shift
+# Account for platform differences in base64 command
+# Taken from @nknapp contribution to traefik: traefik/traefik#2344
+case "$(uname)" in
+  'Linux')
+    # On Linux, -d should always work. --decode does not work with Alpine's busybox-binary
+    CMD_DECODE_BASE64="base64 -d"
+    ;;
+  *)
+    # Max OS-X supports --decode and -D, but --decode may be supported by other platforms as well.
+    CMD_DECODE_BASE64="base64 --decode"
+    ;;
+esac
+
+_temp_dir=$(echo "$1" | ${CMD_DECODE_BASE64}); shift
 _id="$1"; shift
 _exit_on_nonzero="$(tobool "$1")"; shift
 _exit_on_stderr="$(tobool "$1")"; shift
 _exit_on_timeout="$(tobool "$1")"; shift
-_command=$(echo "$1" | base64 -d); shift
+_command=$(echo "$1" | ${CMD_DECODE_BASE64}); shift
 _stdoutfile_name="$1"; shift
 _stderrfile_name="$1"; shift
 _exitcodefile_name="$1"; shift


### PR DESCRIPTION
Hi,

to hopefully get https://github.com/Invicton-Labs/terraform-external-shell-resource/pull/3 moving,
I have transplanted the fix used in https://github.com/traefik/traefik/pull/2344 to your branch.

traefik is MIT licensed and I have credited and linked their PR for this small piece of code so should be totally OK.

They are still using this exact fix today, 5 years later, so it appears to work well for them:

https://github.com/nknapp/traefik/blame/master/contrib/scripts/dumpcerts.sh#L45


I want to push to your fork of the terraform-external-shell-resource repository so when https://github.com/Invicton-Labs/terraform-external-shell-resource/pull/3 gets merged your contribution is credited. If I made my own PR it would be duplicated first of all, but also your contribution would be lost.

Thanks!